### PR TITLE
fix(release.yml): re-added GH_TOKEN after addking it to CI secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,5 +20,6 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Release
         env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx dotenv semantic-release


### PR DESCRIPTION
# Description

Okay, trying this now. Reverted the release.yml to use the secrets of the CI environment instead of trying to assign an environmental variable with dotenv-cli even though that will also happen.